### PR TITLE
Integrate Clerk localization for Spanish (es-MX) support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next'
 import { Poppins } from 'next/font/google'
 import './globals.css'
 import { ClerkProvider } from '@clerk/nextjs'
+import { esMX } from '@clerk/localizations'
 
 const poppins = Poppins({
   subsets: ['latin'],
@@ -108,7 +109,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <ClerkProvider>
+    <ClerkProvider localization={esMX}>
       <html lang='es'>
         <body className={poppins.className}>{children}</body>
       </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pastoral-digital",
       "version": "1.2.0",
       "dependencies": {
+        "@clerk/localizations": "^3.7.0",
         "@clerk/nextjs": "^6.5.0",
         "@ducanh2912/next-pwa": "^10.2.7",
         "@types/auth0-lock": "^11.27.9",
@@ -1947,6 +1948,18 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "license": "0BSD"
     },
+    "node_modules/@clerk/localizations": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@clerk/localizations/-/localizations-3.7.0.tgz",
+      "integrity": "sha512-Vdq1OZ5bbyoDFj9czRV6BesfI02IqynMX9JPyFM+3zo+F+O80CyVGOqdFlwgr7AfCpY+VselC0R9G8YrWxAzGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/types": "4.35.0"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
+    },
     "node_modules/@clerk/nextjs": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.5.0.tgz",
@@ -2694,6 +2707,28 @@
       "license": "MIT",
       "dependencies": {
         "@types/auth0-js": "*"
+      }
+    },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format:write": "prettier --write ."
   },
   "dependencies": {
+    "@clerk/localizations": "^3.7.0",
     "@clerk/nextjs": "^6.5.0",
     "@ducanh2912/next-pwa": "^10.2.7",
     "@types/auth0-lock": "^11.27.9",


### PR DESCRIPTION
Add support for Spanish localization in the Clerk provider by integrating the `esMX` localization. Update dependencies to include `@clerk/localizations`.